### PR TITLE
fix(boxes): use vs16 to force emoji

### DIFF
--- a/src/components/randle.tsx
+++ b/src/components/randle.tsx
@@ -22,19 +22,19 @@ function getGrid (props:GridProps) {
 				const coin = Math.floor(Math.random() * 3);
 				switch(coin) {
 				 case 0:
-				  line += "⬛";
+				  line += "⬛️";
 					break;
 				case 1:
-				  line += "🟨";
+				  line += "🟨️";
 					break;
 				case 2:
-				  line += "🟩";
+				  line += "🟩️";
 					break;
 				};
 			};
 		} else {
 			for(var k = 0; k < props.width; k++) {
-				line += "🟩";
+				line += "🟩️";
 			};
 		}
     grid.push(line);


### PR DESCRIPTION
https://emojipedia.org/variation-selector-16/

second line uses vs16, lower one doesn't 

<img width="339" alt="Screenshot 2022-04-01 at 17 12 11" src="https://user-images.githubusercontent.com/6270048/161291840-5a1072e3-2705-4fd9-ac69-e0ebe4269968.png">
